### PR TITLE
wekaService fix typo

### DIFF
--- a/src/main/java/com/ebiggerr/cPP/service/wekaService.java
+++ b/src/main/java/com/ebiggerr/cPP/service/wekaService.java
@@ -49,7 +49,7 @@ public class wekaService {
 
         if( validInput ) {
 
-            String[] record = {request.getCar_ID(), request.getSymboling(), request.getCarName(), request.getFuelsystem(), request.getAspiration(), request.getDoornumber(), request.getCarbody(), request.getDrivewheel(), request.getEnginelocation(), request.getWheelbase(), request.getCarlength(), request.getCarwidth(), request.getCarheight(), request.getCurbweight(), request.getEnginetype(), request.getCylindernumber(), request.getEnginesize(), request.getFuelsystem(), request.getBoreratio(), request.getStroke(), request.getCompressionratio(), request.getHorsepower(), request.getPeakrpm(), request.getCitympg(), request.getHighwaympg(), "0"};
+            String[] record = {request.getCar_ID(), request.getSymboling(), request.getCarName(), request.getFueltype(), request.getAspiration(), request.getDoornumber(), request.getCarbody(), request.getDrivewheel(), request.getEnginelocation(), request.getWheelbase(), request.getCarlength(), request.getCarwidth(), request.getCarheight(), request.getCurbweight(), request.getEnginetype(), request.getCylindernumber(), request.getEnginesize(), request.getFuelsystem(), request.getBoreratio(), request.getStroke(), request.getCompressionratio(), request.getHorsepower(), request.getPeakrpm(), request.getCitympg(), request.getHighwaympg(), "0"};
 
             //not apply quotes to the values
             writer.writeNext(record, false);


### PR DESCRIPTION
typo fix - causing getFuelSystem() duplicates

fixed by changed one first occurrence to getFueltype(), and remain the second as getFuelSystem